### PR TITLE
chore: add Nix language support in init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -51,6 +51,12 @@
   (setq catppuccin-flavor 'mocha) ;; or 'latte, 'macchiato, or 'mocha
   (catppuccin-reload))
 
+(rc/require 'moe-theme)
+(load-theme 'moe-dark)
+
+(rc/require 'kaolin-themes)
+
+;; disgor rpc
 (rc/require 'elcord)
 (elcord-mode)
 

--- a/init.el
+++ b/init.el
@@ -99,7 +99,6 @@
 ;; Nix language support: syntax highlighting and LSP (nil/nixd)
 (rc/require 'nix-mode)
 (rc/require 'lsp-mode)
-(rc/require 'lsp-nix)
 
 ;; File associations
 (add-to-list 'auto-mode-alist '("\\.nix\\'" . nix-mode))

--- a/init.el
+++ b/init.el
@@ -96,4 +96,20 @@
             (split-window-below)
             ))
 
+;; Nix language support: syntax highlighting and LSP (nil/nixd)
+(rc/require 'nix-mode)
+(rc/require 'lsp-mode)
+(rc/require 'lsp-nix)
+
+;; File associations
+(add-to-list 'auto-mode-alist '("\\.nix\\'" . nix-mode))
+(add-to-list 'auto-mode-alist '("\\.nixinc\\'" . nix-mode))
+
+;; Enable LSP and format-on-save for Nix
+(with-eval-after-load 'nix-mode
+  (add-hook 'nix-mode-hook #'lsp-deferred)
+  (add-hook 'nix-mode-hook
+            (lambda ()
+              (add-hook 'before-save-hook #'lsp-format-buffer nil t))))
+
 ;;; init.el ends here


### PR DESCRIPTION
This pull request adds support for additional themes and introduces Nix language integration to the Emacs configuration. The most important changes are grouped below:

Theme additions:

* Added support for the `moe-theme` and loaded the `moe-dark` variant to provide more theme options.
* Required `kaolin-themes` for further theme customization.

Nix language integration:

* Added `nix-mode` for Nix syntax highlighting and file associations for `.nix` and `.nixinc` files.
* Integrated `lsp-mode` for Nix files, enabling LSP features and automatic formatting on save.